### PR TITLE
Fix infinite spawning of workers by saving options as ints

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -405,7 +405,7 @@ function restoreOptions () {
 // Workerqueue functions
 // These functions are for allowing multiple workers.
 function spawnworkers () {
-  if (workers.length === options.maxworkers) { return }
+  if (workers.length >= options.maxworkers) { return }
   console.log('Spawning %s workers', options.maxworkers)
   for (var i = 0; i < options.maxworkers; i++) {
     var worker = new Worker(chrome.runtime.getURL('scripts/worker.js'))

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -14,11 +14,11 @@ function saveOptions () {
   var maxworkers = document.getElementById('maxWorkers').value
 
   var options = {
-    updateFrequency: updateFrequency,
-    showBest: showBest,
-    minpercentage: minpercentage,
-    maxLengthDifference: maxLengthDifference,
-    maxworkers: maxworkers
+    updateFrequency: parseInt(updateFrequency),
+    showBest: parseInt(showBest),
+    minpercentage: parseInt(minpercentage),
+    maxLengthDifference: parseInt(maxLengthDifference),
+    maxworkers: parseInt(maxworkers)
   }
   chrome.storage.local.set({ options: options }, function () {
     // Update status to let user know options were saved.


### PR DESCRIPTION
This will fix #9 by forcing options to be saved as ints and changing the comparison to greater than. The greater than fix is necessary if a user reduces the number of allowed threads.

Signed-off-by: Alan D. Tse <alandtse@gmail.com>