### PR TITLE
feat(diff): enhance diff view for clarity and usability

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -1360,12 +1360,7 @@ function createNewTabButton(form, selectedLicense, targetDoc = document) {
   
   if (utils.isPopupPage()) return;
   if (targetDoc.querySelector("#newTabButton")) {
-    const existingButton = targetDoc.getElementById("newTabButton");
-    if (existingButton) {
-      existingButton.removeEventListener("click", newTab);
-      existingButton.addEventListener("click", newTab);
-      return;
-    }
+    return;
   }
   
   const button = targetDoc.createElement("button");

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -505,17 +505,21 @@ function displayDiff(html, time = processTime) {
   }
   var spdxid = spdx[0].spdxid;
   var details = spdx[0].details;
+  var percentage = spdx[0].percentage;
+  var distance = spdx[0].distance;
   if (selectedLicense) {
     for (var index in spdx) {
       if (spdx[index].spdxid === selectedLicense) {
         spdxid = selectedLicense;
         details = spdx[index].details;
+        percentage = spdx[index].percentage;
+        distance = spdx[index].distance;
         break;
       }
     }
   }
   
-  const preparedDiff = prepDiff(spdxid, time, html, details);
+  const preparedDiff = prepDiff(spdxid, time, html, details, percentage, distance);
   
   // Use callback approach to setup highlighting immediately after DOM injection
   updateBubbleText(preparedDiff, "#result_text", () => {
@@ -543,9 +547,23 @@ function displayDiff(html, time = processTime) {
         spdxid = spdx[this.options.selectedIndex].spdxid;
         html = diffs[spdxid].html;
         time = diffs[spdxid].time;
-        details = spdx[this.options.selectedIndex].details;
+        for (var index in spdx) {
+          if (spdx[index].spdxid === selectedLicense) {
+            details = spdx[index].details;
+            percentage = spdx[index].percentage;
+            distance = spdx[index].distance;
+            break;
+          }
+        }
         
-        const newPreparedDiff = prepDiff(spdxid, time, html, details);
+        const newPreparedDiff = prepDiff(
+          spdxid,
+          time,
+          html,
+          details,
+          percentage,
+          distance
+        );
         updateBubbleText(newPreparedDiff, "#result_text", () => {
           // Setup highlighting for new selection too
           if (newPreparedDiff.includes('template-variable-row') && newPreparedDiff.includes('diff-variable-highlight')) {
@@ -918,7 +936,7 @@ function retryHighlightingSetupIfNeeded() {
 }
 
 // This wraps the diff display
-function prepDiff(spdxid, time, html, details) {
+function prepDiff(spdxid, time, html, details, percentage, distance) {
   var hoverInfo = "tags: ";
   for (var filter in filters) {
     if (details[filters[filter]]) {
@@ -928,10 +946,40 @@ function prepDiff(spdxid, time, html, details) {
   if (details.licenseComments) {
     hoverInfo += "&#10;comments: " + _.escape(details.licenseComments);
   }
-  var title = `<a href="https://spdx.org/licenses/${spdxid}.html" target="_blank" title="${hoverInfo}">${details.name} (${spdxid})</a>`;
+
+  let confidenceIndicator = '';
+  if (percentage !== undefined) {
+      let confidenceText = '';
+      let confidenceClass = '';
+      let icon = '';
+
+      if (percentage >= 90) {
+          confidenceText = 'Good Match';
+          confidenceClass = 'full-match';
+          icon = '✔';
+      } else if (percentage >= 30) {
+          confidenceText = 'Partial Match';
+          confidenceClass = 'partial-match';
+          icon = '⚠';
+      } else {
+          confidenceText = 'Low Match';
+          confidenceClass = 'no-match';
+          icon = '✖';
+      }
+      confidenceIndicator = `<span class="confidence-indicator ${confidenceClass}" title="Match: ${percentage}%"><span class="confidence-icon">${icon}</span> ${confidenceText}</span>`;
+  }
+
+  var title = `<a href="https://spdx.org/licenses/${spdxid}.html" target="_blank" title="${hoverInfo}">${details.name} (${spdxid})</a>${confidenceIndicator}`;
   var timehtml =
     " processed in " + (time + processTime) / 1000 + "s<br /><hr />";
   
+  const legend = `
+    <div class="diff-legend">
+      <div class="legend-item"><span class="legend-color-sample diff-insert-legend"></span>Text in your selection but not in license</div>
+      <div class="legend-item"><span class="legend-color-sample diff-delete-legend"></span>Text in license but not in your selection</div>
+    </div>
+  `;
+
   // Find templateMatch data for this license - only show for actual template matches
   var templateTable = "";
   if (spdx) {
@@ -946,7 +994,7 @@ function prepDiff(spdxid, time, html, details) {
     }
   }
   
-  const result = title + timehtml + templateTable + html;
+  const result = title + timehtml + legend + templateTable + html;
   
   // Setup highlighting directly in the next frame after content is injected
   // This approach eliminates race conditions by being synchronous with the DOM update
@@ -1028,40 +1076,50 @@ function addSelectFormFromArray(id, arr, number = arr.length, minimum = 0) {
   var select = form.appendChild(document.createElement("select"));
   select.id = id;
   for (var i = 0; i < arr.length && i < number; i++) {
-    var value = arr[i].spdxid;
-    var percentage = arr[i].percentage;
-    var dice = arr[i].dice;
-    var text =
-      value +
-      " : " +
-      percentage +
-      "% match (" +
-      arr[i].distance +
-      " differences / dice-coefficient " +
-      dice +
-      ")";
-    if (percentage === 100) {
-      text =
-        value +
-        " : " +
-        percentage +
-        "% template match (" +
-        arr[i].distance +
-        " differences / dice-coefficient " +
-        dice +
-        ")";
-    }
-
-    if (Number(percentage) < Number(minimum)) {
-      // No match at all
+    var option = document.createElement("option");
+    var license = arr[i];
+    if (Number(license.percentage) < Number(minimum)) {
       break;
     }
-    var option = select.appendChild(document.createElement("option"));
-    option.value = value;
-    option.text = text;
-    if (diffs[value] === undefined) {
-      option.setAttribute("disabled", "disabled");
+    
+    let icon = '';
+    if (license.percentage >= 90) {
+        icon = '✔ ';
+    } else if (license.percentage >= 30) {
+        icon = '⚠ ';
+    } else {
+        icon = '✖ ';
     }
+
+    var text =
+      license.spdxid +
+      " : " +
+      license.percentage +
+      "% match (" +
+      license.distance +
+      " differences";
+    if (license.dice) {
+      text += " / dice-coefficient " + license.dice;
+    }
+    text += ")";
+    option.value = license.spdxid;
+    option.appendChild(document.createTextNode(icon + text));
+
+    // Add confidence class to option for styling
+    let confidenceClass = '';
+    if (license.percentage >= 90) {
+        confidenceClass = 'full-match';
+    } else if (license.percentage >= 30) {
+        confidenceClass = 'partial-match';
+    } else {
+        confidenceClass = 'no-match';
+    }
+    option.classList.add(confidenceClass);
+
+    if (diffs[license.spdxid] === undefined) {
+      option.disabled = true;
+    }
+    select.appendChild(option);
   }
   createNewLicenseButton(form);
   createNewTabButton(form, selectedLicense);

--- a/app/scripts/worker.js
+++ b/app/scripts/worker.js
@@ -71,7 +71,7 @@ function diff_prettyHtml(diffs, templateMatch, selection) {
       text = data.replace(pattern_amp, '&amp;')
                  .replace(pattern_lt, '&lt;')
                  .replace(pattern_gt, '&gt;')
-                 .replace(pattern_para, '&para;<br>');
+                 .replace(pattern_para, '<br>');
     }
     
     switch (op) {
@@ -137,7 +137,7 @@ function wrapVariableTextInDiffWithEscaping(originalText, textStartPos, variable
     return originalText.replace(pattern_amp, '&amp;')
                       .replace(pattern_lt, '&lt;')
                       .replace(pattern_gt, '&gt;')
-                      .replace(pattern_para, '&para;<br>');
+                      .replace(pattern_para, '<br>');
   }
   
   // Sort by relative position to handle them in order
@@ -154,7 +154,7 @@ function wrapVariableTextInDiffWithEscaping(originalText, textStartPos, variable
       result += beforeText.replace(pattern_amp, '&amp;')
                          .replace(pattern_lt, '&lt;')
                          .replace(pattern_gt, '&gt;')
-                         .replace(pattern_para, '&para;<br>');
+                         .replace(pattern_para, '<br>');
     }
     
     // Add the variable text with highlighting span
@@ -162,7 +162,7 @@ function wrapVariableTextInDiffWithEscaping(originalText, textStartPos, variable
     const escapedVariableText = variableText.replace(pattern_amp, '&amp;')
                                            .replace(pattern_lt, '&lt;')
                                            .replace(pattern_gt, '&gt;')
-                                           .replace(pattern_para, '&para;<br>');
+                                           .replace(pattern_para, '<br>');
     
     result += '<span class="diff-variable-highlight" data-variable-name="' + 
               escapeHtmlAttributes(segVar.variableName) + '" data-variable-index="' + segVar.variableIndex + '">' + 
@@ -179,7 +179,7 @@ function wrapVariableTextInDiffWithEscaping(originalText, textStartPos, variable
     result += afterText.replace(pattern_amp, '&amp;')
                       .replace(pattern_lt, '&lt;')
                       .replace(pattern_gt, '&gt;')
-                      .replace(pattern_para, '&para;<br>');
+                      .replace(pattern_para, '<br>');
   }
   
   return result;

--- a/app/styles/contentscript.css
+++ b/app/styles/contentscript.css
@@ -805,3 +805,163 @@ body[data-is-popup] .spdx-dark-mode .selection_bubble a {
 body[data-is-popup] .selection_bubble.spdx-dark-mode ~ * {
   color: #e2e8f0 !important;
 }
+
+/* Diff Legend */
+.diff-legend {
+  font-size: 12px;
+  margin-bottom: 10px;
+  padding: 8px;
+  border: 1px solid #dee2e6;
+  border-radius: 4px;
+  background-color: #f8f9fa;
+}
+
+.diff-legend .legend-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.diff-legend .legend-item:last-child {
+  margin-bottom: 0;
+}
+
+.diff-legend .legend-color-sample {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-right: 8px;
+  border: 1px solid rgba(0,0,0,0.1);
+  flex-shrink: 0;
+}
+
+.diff-legend .legend-symbol {
+  display: inline-block;
+  width: 12px;
+  text-align: center;
+  margin-right: 8px;
+  font-weight: bold;
+  flex-shrink: 0;
+}
+
+.diff-insert-legend {
+  background-color: #d4edda;
+}
+
+.diff-delete-legend {
+  background-color: #f8d7da;
+}
+
+/* Confidence indicator styles */
+.confidence-indicator {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: bold;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+.confidence-icon {
+  margin-right: 4px;
+}
+
+.full-match {
+  background-color: #e9f7ec;
+  color: #0c6b37;
+}
+
+.partial-match {
+  background-color: #fff9e6;
+  color: #7a5900;
+}
+
+.no-match {
+  background-color: #fde8e9;
+  color: #8c2f39;
+}
+
+/* Dropdown option colors (Note: May not render on all browsers, e.g., Firefox) */
+#licenses option.full-match {
+  background-color: #e9f7ec !important;
+  color: #0c6b37 !important;
+}
+
+#licenses option.partial-match {
+  background-color: #fff9e6 !important;
+  color: #7a5900 !important;
+}
+
+#licenses option.no-match {
+  background-color: #fde8e9 !important;
+  color: #8c2f39 !important;
+}
+
+/* Manual dark mode override */
+.spdx-dark-mode ins.diff-insert,
+.spdx-dark-mode .diff-insert {
+  background-color: #0d4920 !important;
+  color: #7dd3fc !important;
+}
+
+.spdx-dark-mode .diff-variable-highlight.highlighted {
+  background-color: rgba(255, 235, 59, 0.4) !important;
+  border-color: rgba(255, 235, 59, 0.7) !important;
+  box-shadow: 0 0 0 2px rgba(255, 235, 59, 0.2) !important;
+}
+
+/* Dark Mode Legend */
+.spdx-dark-mode .diff-legend {
+  background-color: #374151;
+  border-color: #4a5568;
+  color: #e5e7eb;
+}
+
+.spdx-dark-mode .diff-insert-legend {
+  background-color: #0d4920;
+}
+
+.spdx-dark-mode .diff-delete-legend {
+  background-color: #5a1e1e;
+}
+
+/* Dark mode for confidence indicators */
+.spdx-dark-mode .full-match {
+  background-color: #1c3b29;
+  color: #a7f3d0;
+}
+
+.spdx-dark-mode .partial-match {
+  background-color: #423400;
+  color: #fde088;
+}
+
+.spdx-dark-mode .no-match {
+  background-color: #442024;
+  color: #fecaca;
+}
+
+/* Dark mode for dropdown options */
+.spdx-dark-mode #licenses option.full-match {
+  background-color: #1c3b29 !important;
+  color: #a7f3d0 !important;
+}
+
+.spdx-dark-mode #licenses option.partial-match {
+  background-color: #423400 !important;
+  color: #fde088 !important;
+}
+
+.spdx-dark-mode #licenses option.no-match {
+  background-color: #442024 !important;
+  color: #fecaca !important;
+}
+
+/* Dark mode override for the main bubble background */
+.spdx-dark-mode.selection_bubble,
+.spdx-dark-mode .selection_bubble {
+  background: #2d3748 !important;
+  color: #e2e8f0 !important;
+  border-color: #4a5568 !important;
+}


### PR DESCRIPTION
Adds a small info to the diff view to explain the color-coding for insertions (green) and deletions (red).

Implements match confidence indicators to categorize results as 'Good Match' (>=90%), 'Partial Match' (>=30%), or 'Low Match' (<30%). These indicators appear next to the license title and as icons in the dropdown.

Adds corresponding colors to the dropdown options to reflect match confidence, with a lighter color palette for better visibility and dark mode support.

Removes the pilcrow (¶) symbol from the end of lines in the diff view for a cleaner appearance.

Corrects an issue where the "expand" button would open multiple new tabs instead of just one.

[Screencast from 2025-06-27 23-52-17.webm](https://github.com/user-attachments/assets/bd9006ad-f4e6-4635-8035-6550428aca95)
