### PR TITLE
feat: implement fault-tolerant license downloads with transparent reporting

### DIFF
--- a/app/pages/options.html
+++ b/app/pages/options.html
@@ -39,6 +39,7 @@
     <td><div id="storagestatus"></div></td>
   </tr>
   </table>
+    <div id="downloadStatus" class="status-container"></div>
     <button id="update">Update List</button>
     <button id="clearstorage">Clear Storage</button>
   </div>

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -657,118 +657,7 @@ function workeronmessage(event) {
       //     }
       // });
       break;
-    case "savelicenselist":
-      type = event.data.type;
-      var externallicenselist = event.data.value;
-      var externalversion = externallicenselist.licenseListVersion;
-      var externalcount = externallicenselist[type]
-        ? Object.keys(externallicenselist[type]).length
-        : 0;
-      console.log("Trying to save list", externallicenselist);
-      getStorage("list").then(function (result) {
-        if (result.list && result.list.licenseListVersion) {
-          var storedlist = result.list;
-          var version = storedlist.licenseListVersion;
-          var count = storedlist[type]
-            ? Object.keys(storedlist[type]).length
-            : 0;
-          console.log(
-            "Existing License list version %s with %s %s",
-            version,
-            count,
-            type
-          );
-          if (version < externalversion) {
-            storedlist[type] = externallicenselist[type];
-            console.log(
-              "Newer license list version %s found with %s %s",
-              externalversion,
-              externalcount,
-              type
-            );
-            storeList(storedlist);
-            if (list[type + "dict"]) {
-              storedlist[type + "dict"] = list[type + "dict"];
-            }
-            list[type] = storedlist[type];
-          } else if (count < externalcount) {
-            storedlist[type] = externallicenselist[type];
-            console.log(
-              "New list version %s found with %s %s more than old list with %s %s",
-              externalversion,
-              externalcount,
-              type,
-              count,
-              type
-            );
-            storeList(storedlist);
-            if (list[type + "dict"]) {
-              storedlist[type + "dict"] = list[type + "dict"];
-            }
-            list[type] = storedlist[type];
-          } else {
-            // dowork({ 'command': 'populatelicenselist', 'data': list })
-            console.log(
-              "No new update found; same version %s and with %s %s",
-              externalversion,
-              externalcount,
-              type
-            );
-            if (list[type + "dict"]) {
-              storedlist[type + "dict"] = list[type + "dict"];
-            }
-            list[type] = storedlist[type];
-          }
-        } else {
-          console.log("No existing license list found; storing");
-          storeList(externallicenselist);
-          list = externallicenselist;
-        }
-        checkUpdateDone();
-      });
 
-      break;
-    case "saveitem":
-      if (updating) {
-        item = event.data;
-        type = event.data.type;
-        spdxid = item.data[spdxkey[type].id];
-        if (list[type + "dict"] === undefined) {
-          list[type + "dict"] = {};
-        }
-        list[type + "dict"][spdxid] = item.data;
-        checkUpdateDone();
-        console.log("Saving %s: %s", type, spdxid, item.data);
-        getStorage(spdxid).then(function (result) {
-          if (
-            result[spdxid] &&
-            item.data &&
-            _.isEqual(result[spdxid], item.data)
-          ) {
-            // var license = result[spdxid]
-            console.log("Ignoring existing %s %s", type, spdxid);
-          } else {
-            console.log("Saving new %s %s", type, spdxid);
-            var obj = {};
-            obj[spdxid] = item.data;
-            api.storage.local.set(obj, function () {
-              console.log("Storing", obj);
-            });
-          }
-        });
-      } else {
-        console.log(
-          "Not supposed to update but received saveitem request; ignoring",
-          event.data
-        );
-      }
-      break;
-    case "updatedone":
-      workerdone(event.data.id);
-      type = event.data.type;
-      console.log("Received worker update completion for %s", type);
-      checkUpdateDone();
-      break;
     case "updateerror": {
       workerdone(event.data.id);
       const updateType = event.data.type;
@@ -936,6 +825,7 @@ function workeronmessage(event) {
 
       updating = false;
       sendMessageToOptionsPage("update_status", `License list updated to v.${list.licenseListVersion}`, "success");
+      launchPendingCompares();
       break;
     }
     case "updatefailed": {
@@ -1421,38 +1311,7 @@ const setStorage = function (obj) {
   });
 };
 
-const checkUpdateDone = function () {
-  const types = Object.keys(urls);
-  try {
-    if (
-      types.every((type) => {
-        return (
-          list[type] &&
-          list[type + "dict"] &&
-          list[type].length === Object.keys(list[type + "dict"]).length
-        );
-      })
-    ) {
-      console.log("Update completed");
-      updating = false;
-      // Notify options page of successful update
-      sendMessageToOptionsPage("update_status", "License list updated successfully!", "success");
-      launchPendingCompares();
-    } else {
-      types.map((type) => {
-        console.log(
-          "Update in progress for %s %s/%s",
-          type,
-          list[type + "dict"] ? Object.keys(list[type + "dict"]).length : 0,
-          list[type] ? list[type].length : 0
-        );
-      });
-    }
-  } catch (err) {
-    console.log("Error in checkUpdateDone");
-    throw err;
-  }
-};
+
 
 chrome.runtime.onInstalled.addListener(function (details) {
   if (details.reason === "install") {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -590,8 +590,6 @@ function workeronmessage(event) {
   ); // Message received so see if queue can be cleared.
   var result;
   var threadid;
-  var type;
-  var item;
   switch (event.data.command) {
     case "progressbarmax":
       var tabId =

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -211,23 +211,6 @@ function loadList() {
     var licenseversion = document.getElementById("licenseversion");
     var status = document.getElementById("updatestatus");
 
-    // FAKE DATA FOR TESTING - show fake data to test the UI
-    // result.list = {
-    //   licenseListVersion: "3.24.0-fake",
-    //   releaseDate: "2024-01-15",
-    //   lastupdate: Date.now(),
-    //   licenses: [
-    //     { licenseId: "MIT", name: "MIT License" },
-    //     { licenseId: "Apache-2.0", name: "Apache License 2.0" },
-    //     { licenseId: "GPL-3.0-only", name: "GNU General Public License v3.0 only" },
-    //     { licenseId: "BSD-3-Clause", name: "BSD 3-Clause License" },
-    //     { licenseId: "ISC", name: "ISC License" },
-    //     { licenseId: "CC-BY-4.0", name: "Creative Commons Attribution 4.0 International" },
-    //     { licenseId: "Mozilla-2.0", name: "Mozilla Public License 2.0" }
-    //   ],
-    //   failedDownloads: ["CC-BY-1.0", "WTFPL", "vxWorks"] // Show some failed downloads too
-    // };
-
     if (result.list && result.list.licenseListVersion) {
       var list = result.list;
       var lastupdate = list.lastupdate;

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -223,6 +223,21 @@ function loadList() {
         list.licenses.length +
         " licenses";
       status.textContent = new Date(lastupdate).toLocaleString();
+
+      // Display failed downloads if any
+      const downloadStatusDiv = document.getElementById("downloadStatus");
+      if (list.failedDownloads && list.failedDownloads.length > 0) {
+        downloadStatusDiv.innerHTML = `
+          <p class="status-title"><strong>Warning:</strong> The following licenses could not be downloaded during the last update:</p>
+          <ul class="failed-list">
+            ${list.failedDownloads.map(id => `<li>${id}</li>`).join('')}
+          </ul>
+        `;
+        downloadStatusDiv.className = 'status-container status-warning';
+      } else {
+        downloadStatusDiv.innerHTML = '<p class="status-title status-success">All licenses were downloaded successfully.</p>';
+        downloadStatusDiv.className = 'status-container status-success';
+      }
     } else {
       licenseversion.textContent = "None";
       status.textContent = "Never";

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -210,6 +210,24 @@ function loadList() {
   api.storage.local.get(["list"], function (result) {
     var licenseversion = document.getElementById("licenseversion");
     var status = document.getElementById("updatestatus");
+
+    // FAKE DATA FOR TESTING - show fake data to test the UI
+    result.list = {
+      licenseListVersion: "3.24.0-fake",
+      releaseDate: "2024-01-15",
+      lastupdate: Date.now(),
+      licenses: [
+        { licenseId: "MIT", name: "MIT License" },
+        { licenseId: "Apache-2.0", name: "Apache License 2.0" },
+        { licenseId: "GPL-3.0-only", name: "GNU General Public License v3.0 only" },
+        { licenseId: "BSD-3-Clause", name: "BSD 3-Clause License" },
+        { licenseId: "ISC", name: "ISC License" },
+        { licenseId: "CC-BY-4.0", name: "Creative Commons Attribution 4.0 International" },
+        { licenseId: "Mozilla-2.0", name: "Mozilla Public License 2.0" }
+      ],
+      failedDownloads: ["CC-BY-1.0", "WTFPL", "vxWorks"] // Show some failed downloads too
+    };
+
     if (result.list && result.list.licenseListVersion) {
       var list = result.list;
       var lastupdate = list.lastupdate;

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -212,21 +212,21 @@ function loadList() {
     var status = document.getElementById("updatestatus");
 
     // FAKE DATA FOR TESTING - show fake data to test the UI
-    result.list = {
-      licenseListVersion: "3.24.0-fake",
-      releaseDate: "2024-01-15",
-      lastupdate: Date.now(),
-      licenses: [
-        { licenseId: "MIT", name: "MIT License" },
-        { licenseId: "Apache-2.0", name: "Apache License 2.0" },
-        { licenseId: "GPL-3.0-only", name: "GNU General Public License v3.0 only" },
-        { licenseId: "BSD-3-Clause", name: "BSD 3-Clause License" },
-        { licenseId: "ISC", name: "ISC License" },
-        { licenseId: "CC-BY-4.0", name: "Creative Commons Attribution 4.0 International" },
-        { licenseId: "Mozilla-2.0", name: "Mozilla Public License 2.0" }
-      ],
-      failedDownloads: ["CC-BY-1.0", "WTFPL", "vxWorks"] // Show some failed downloads too
-    };
+    // result.list = {
+    //   licenseListVersion: "3.24.0-fake",
+    //   releaseDate: "2024-01-15",
+    //   lastupdate: Date.now(),
+    //   licenses: [
+    //     { licenseId: "MIT", name: "MIT License" },
+    //     { licenseId: "Apache-2.0", name: "Apache License 2.0" },
+    //     { licenseId: "GPL-3.0-only", name: "GNU General Public License v3.0 only" },
+    //     { licenseId: "BSD-3-Clause", name: "BSD 3-Clause License" },
+    //     { licenseId: "ISC", name: "ISC License" },
+    //     { licenseId: "CC-BY-4.0", name: "Creative Commons Attribution 4.0 International" },
+    //     { licenseId: "Mozilla-2.0", name: "Mozilla Public License 2.0" }
+    //   ],
+    //   failedDownloads: ["CC-BY-1.0", "WTFPL", "vxWorks"] // Show some failed downloads too
+    // };
 
     if (result.list && result.list.licenseListVersion) {
       var list = result.list;


### PR DESCRIPTION
### Problem
Single license download failures (e.g., 404 errors) would crash the entire update process, leaving users stuck in "forever updating" state with no license comparison functionality.

### Solution
- Fault-tolerant downloads: Individual license failures no longer break entire updates
- Atomic updates: License data replaced only when complete and validated
- Transparent reporting: Users see specific failed license names instead of silent failures
- Enhanced UX: Fixed double-click requirement and disappearing status fields

### Key Changes
- Replace fragile incremental updates with atomic completion in worker.js
- Add updatelistcomplete/updatefailed handlers in background.js
- Remove obsolete savelicenselist/saveitem/updatedone handlers
- Add transparent status display in options page
- Fix UI race conditions and status message conflicts

### Impact
- Extensions remains functional even if some licenses fail to download
- Users see clear status: "All licenses downloaded" or "Failed: license1, license2..."
- Single-click updates work reliably
- No more "forever updating" state

#### Success Message (options.html)
![Screenshot from 2025-07-01 14-12-16](https://github.com/user-attachments/assets/5bac55ec-82b5-47fd-94d5-fee02053a1b2)

#### License Failure List (options.html)
![Screenshot from 2025-07-01 14-29-44](https://github.com/user-attachments/assets/4037b37a-6e0d-45d6-af27-c4c70ba81200)

Closes #52