### PR TITLE
ci: upgrade node version to 22.x for compatibility

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['>=20.8.1 <21.0.0']
+        node-version: ['22.x']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['>=20.8.1 <21.0.0']
+        node-version: ['22.x']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Upgrades Node.js version matrix in semantic-release and test PR workflows to 22.x. This satisfies semantic-release v25's requirements of Node >=22.14.0.