### PR TITLE
ci: enable yarn caching in github actions workflows

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
       #- name: install yarn
       #  run: |
       #    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn install


### PR DESCRIPTION
Enables Yarn dependency caching in `setup-node` steps for both the release and test PR workflows. This speeds up CI runs by reusing cached node modules.