### PR TITLE
ci: upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initialize CodeQL tools for scanning
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # For JavaScript/TypeScript, CodeQL can analyze without building
@@ -61,6 +61,6 @@ jobs:
     #     npm run build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -21,4 +21,4 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v2
+      uses: fsfe/reuse-action@v6


### PR DESCRIPTION
Bumps fsfe/reuse-action from v2 to v6 and github/codeql-action from v3 to v4 to align with latest recommendations and resolve upcoming CodeQL v3 deprecation warnings.