### PR TITLE
ci: harden GITHUB_TOKEN permissions for test and keep-alive workflows

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -6,6 +6,8 @@ on:
     - cron: '0 0 1 * *'
   workflow_dispatch: # Allows manual triggering from the GitHub Actions tab
 
+permissions: {}
+
 jobs:
   keep-alive:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Restricts default GITHUB_TOKEN permissions in GHA to read-only for contents (test workflow) and empty (keep-alive token refresh workflow) to satisfy CodeQL security policies.