### PR TITLE
test: add Jest unit testing

### DIFF
--- a/app/scripts/worker.js
+++ b/app/scripts/worker.js
@@ -778,3 +778,5 @@ const get = function (url) {
 const getJSON = async function (url) {
   return get(url).then(JSON.parse);
 };
+
+export { cleanText, replaceSmartQuotes };

--- a/app/scripts/worker.test.js
+++ b/app/scripts/worker.test.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Alan D. Tse <alandtse@gmail.com>
+// SPDX-License-Identifier: (GPL-3.0-or-later AND Apache-2.0)
+
 /* eslint-env jest, node */
 
 global.self = global;

--- a/app/scripts/worker.test.js
+++ b/app/scripts/worker.test.js
@@ -1,0 +1,20 @@
+/* eslint-env jest, node */
+
+global.self = global;
+
+const {
+  cleanText,
+  replaceSmartQuotes
+} = require('./worker.js');
+
+describe('worker normalization helper functions', () => {
+  test('replaceSmartQuotes should normalize smart single and double quotes', () => {
+    expect(replaceSmartQuotes('“hello” and ‘world’')).toBe('"hello" and \'world\'');
+  });
+
+  test('cleanText should perform basic quotes and spaces normalization', () => {
+    const input = 'This is a test: “hello”  world';
+    const expected = 'This is a test: "hello" world';
+    expect(cleanText(input)).toBe(expected);
+  });
+});

--- a/app/scripts/worker.test.js
+++ b/app/scripts/worker.test.js
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Alan D. Tse <alandtse@gmail.com>
 // SPDX-License-Identifier: (GPL-3.0-or-later AND Apache-2.0)
 
-/* eslint-env jest, node */
-
 global.self = global;
 
 const {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }]
+  ]
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Alan D. Tse <alandtse@gmail.com>
+// SPDX-License-Identifier: CC0-1.0
+
 module.exports = {
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Alan D. Tse <alandtse@gmail.com>
 // SPDX-License-Identifier: CC0-1.0
 import js from "@eslint/js";
+import globals from "globals";
 
 export default [
     js.configs.recommended,
@@ -66,5 +67,14 @@ export default [
             "no-console": "off",
             "no-empty": ["error", { "allowEmptyCatch": true }]
         },
+    },
+    {
+        files: ["**/*.test.js", "**/*.spec.js"],
+        languageOptions: {
+            globals: {
+                ...globals.jest,
+                ...globals.node
+            }
+        }
     }
 ];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint app",
     "changelog": "gren c --generate --override -B -t all",
     "attribution": "npx generate-attribution --production",
-    "test": "yarn lint && yarn install && yarn build chrome && yarn build firefox && yarn build opera && yarn build edge",
+    "test": "jest && yarn lint && yarn install && yarn build chrome && yarn build firefox && yarn build opera && yarn build edge",
+    "test:unit": "jest",
     "production": "([ ! -z $GITHUB_WORKFLOW ] || (yarn lint && yarn install)) && yarn build chrome && yarn build firefox && yarn build opera && yarn build edge",
     "buildall": "yarn clean && yarn attribution && yarn production"
   },
@@ -45,6 +46,7 @@
     "eslint-plugin-promise": "^7.3.0",
     "github-release-notes": "^0.17.3",
     "globals": "^17.6.0",
+    "jest": "^30.4.2",
     "oss-attribution-generator": "^1.7.1",
     "prettier": "^3.8.4",
     "semantic-release": "^25.0.5",
@@ -169,5 +171,11 @@
     "jws": "^3.2.3",
     "launch-editor": "^2.14.1",
     "shell-quote": "^1.8.4"
+  },
+  "jest": {
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ]
   }
 }


### PR DESCRIPTION
Integrates the Jest testing framework with Babel configuration, configures flat ESLint globals for test files, and adds basic unit tests for the license worker's normalization functions.